### PR TITLE
fix #33, fix #35

### DIFF
--- a/lib/helpers/grid_helpers.dart
+++ b/lib/helpers/grid_helpers.dart
@@ -99,14 +99,8 @@ class SliverGridRegularTileLayoutAndLoading
   @override
   SliverGridGeometry getGeometryForChildIndex(int index) {
     if (index == this.itemCount - 1) {
-      int displayIndex = index;
-      if (index.remainder(this.crossAxisCount) != 0) {
-        displayIndex = index +
-            (this.crossAxisCount - index.remainder(this.crossAxisCount));
-      }
       return SliverGridGeometry(
-          scrollOffset:
-              (displayIndex ~/ this.crossAxisCount) * this.mainAxisStride,
+          scrollOffset: (index ~/ this.crossAxisCount) * this.mainAxisStride,
           crossAxisOffset: 0.0,
           mainAxisExtent: this.childMainAxisExtent,
           crossAxisExtent: this.fullCrossAccessExtent);


### PR DESCRIPTION
In GridView, when we receive, in the last page, a page size that is smaller than the pageSize, we were shifting the LoadingWidget one row below. Which was causing problems. To avoid that shifting, now we append a few more elements to the last page, which solves the problem.