### PR TITLE
fix #32

### DIFF
--- a/lib/flutter_pagewise.dart
+++ b/lib/flutter_pagewise.dart
@@ -438,7 +438,7 @@ class PagewiseLoadController<T> extends ChangeNotifier {
   }
 
   /// Resets all the information of the controller
-  reset() {
+  Future<void> reset() {
     this._appendedItems = [];
     this._loadedItems = [];
     this._numberOfLoadedPages = 0;


### PR DESCRIPTION
Make reset of the `PagewiseLoadController` return a Future<void> to avoid possible exceptions.