### PR TITLE
Update the environment to remove the health hints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   async: ^2.0.7
 environment:
-    sdk: ">=1.19.0 <3.0.0"
+    sdk: ">=2.1.0 <3.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The dart website reports the following about the package:
The class 'Future' was not exported from 'dart:core' until version 2.1, but this code is required to be able to run on earlier versions.
This should fix it