### PR TITLE
Default retry widget button shouldn't specify colors so as not to clash with app's theme

### DIFF
--- a/lib/flutter_pagewise.dart
+++ b/lib/flutter_pagewise.dart
@@ -311,10 +311,8 @@ class PagewiseState<T> extends State<Pagewise<T>> {
   Widget _getRetryWidget() {
     var defaultRetryButton = FlatButton(
       child: Icon(
-        Icons.refresh,
-        color: Colors.white,
+        Icons.refresh
       ),
-      color: Colors.grey[300],
       shape: CircleBorder(),
       onPressed: this._effectiveController.retry,
     );


### PR DESCRIPTION
Use the app's default/inherited button themes instead. 