### PR TITLE
Use TextButton instead of FlatButton

### DIFF
--- a/lib/flutter_pagewise.dart
+++ b/lib/flutter_pagewise.dart
@@ -309,13 +309,15 @@ class PagewiseState<T> extends State<Pagewise<T>> {
   }
 
   Widget _getRetryWidget() {
-    var defaultRetryButton = FlatButton(
+    var defaultRetryButton = TextButton(
+      style: TextButton.styleFrom(
+        backgroundColor: Colors.grey[300],
+        shape: CircleBorder(),
+      ),
       child: Icon(
         Icons.refresh,
         color: Colors.white,
       ),
-      color: Colors.grey[300],
-      shape: CircleBorder(),
       onPressed: this._effectiveController!.retry,
     );
 


### PR DESCRIPTION
FlatButton was removed from Flutter >= 3.3.0.

Signed-off-by: Martin Edlman <ac@an.y-co.de>