### PR TITLE
Allow the number of items to exceed the page size

### DIFF
--- a/lib/flutter_pagewise.dart
+++ b/lib/flutter_pagewise.dart
@@ -162,8 +162,7 @@ abstract class Pagewise<T> extends StatefulWidget {
       required this.itemBuilder,
       this.errorBuilder,
       required this.builder})
-      : assert(showRetry != null),
-        assert((pageLoadController == null &&
+      : assert((pageLoadController == null &&
                 pageSize != null &&
                 pageFuture != null) ||
             (pageLoadController != null &&

--- a/lib/helpers/grid_helpers.dart
+++ b/lib/helpers/grid_helpers.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 class SliverGridDelegateWithFixedCrossAxisCountAndLoading


### PR DESCRIPTION
Sometimes it can be handy to have more items in response than page size. Either from backend or modified in flutter application. I did this patch when I needed to use `easy_sticky_header` to have sticky headers in the pagewise list. It's  needed to add extra items for eheaders to the list and thus have more items than page size.